### PR TITLE
refactor: improve local D1 database auto-discovery in drizzle config

### DIFF
--- a/drizzle.local.config.ts
+++ b/drizzle.local.config.ts
@@ -1,10 +1,30 @@
 import { defineConfig } from "drizzle-kit";
+import path from "path";
+import * as fs from "node:fs";
+
+function getLocalD1DB() {
+  try {
+    const basePath = path.resolve(".wrangler");
+    const dbFile = fs
+      .readdirSync(basePath, { encoding: "utf-8", recursive: true })
+      .find((f) => f.endsWith(".sqlite"));
+
+    if (!dbFile) {
+      return undefined;
+    }
+
+    return path.resolve(basePath, dbFile);
+  } catch (error) {
+    console.error("Error reading local D1 database file:", error);
+    return undefined;
+  }
+}
 
 export default defineConfig({
     schema: "./src/db/schema.ts",
     out: "./src/drizzle",
     dialect: "sqlite",
     dbCredentials: {
-        url: "file:./.wrangler/state/v3/d1/miniflare-D1DatabaseObject/be1c14135daa5434f0307e4141c5ae761791f49828a594a2ee437ac594cdd108.sqlite",
+        url: getLocalD1DB() || "file:./dev.db",
     },
 });


### PR DESCRIPTION
Update drizzle.local.config.ts to automatically locate SQLite database files in the .wrangler directory instead of using hardcoded paths, with fallback to dev.db for better local development experience.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved local development database configuration to automatically detect an existing local database when available, with a safe fallback to a default development database.
  * Enhanced error handling and logging during local database discovery to prevent crashes and simplify troubleshooting.
  * Increases reliability for developers running the app locally without affecting production behavior or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->