### PR TITLE
fix: auto-detect port in auth client baseURL

### DIFF
--- a/src/modules/auth/utils/auth-client.ts
+++ b/src/modules/auth/utils/auth-client.ts
@@ -4,9 +4,7 @@ import { createAuthClient } from "better-auth/react";
 // The baseURL will be automatically determined from the current origin
 export const authClient = createAuthClient({
     baseURL:
-        process.env.NODE_ENV === "development"
-            ? "http://localhost:3000"
-            : typeof window !== "undefined"
-              ? window.location.origin
-              : "",
+        typeof window !== "undefined"
+            ? window.location.origin // Auto-detect from browser URL (works for any port)
+            : process.env.NEXT_PUBLIC_AUTH_URL || "http://localhost:3000", // Fallback for SSR
 });


### PR DESCRIPTION
## Problem
The auth client hardcodes `localhost:3000`, which breaks when:
- Port 3000 is already in use (Next.js auto-assigns 3001, 3002, etc.)
- Running multiple dev instances simultaneously
- Testing on different ports

## Solution
Use `window.location.origin` to auto-detect the current URL in the browser. This works for:
- Any localhost port (3000, 3001, 8080, etc.)
- Production deployments
- Custom domains

Falls back to `NEXT_PUBLIC_AUTH_URL` env var for SSR compatibility.

## Testing
- ✅ Tested with Next.js on port 3001 (when 3000 was in use)
- ✅ Google OAuth login works correctly
- ✅ No hardcoded ports needed

## Changes
- Modified `src/modules/auth/utils/auth-client.ts`
- Changed from hardcoded port to dynamic detection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication URL detection to properly handle both browser and server environments, ensuring correct URL resolution in all runtime contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->