### PR TITLE
fix: correct todos navigation link path

### DIFF
--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -22,7 +22,7 @@ export function Navigation() {
                                     Home
                                 </Button>
                             </Link>
-                            <Link href="/todos">
+                            <Link href="/dashboard/todos">
                                 <Button variant="ghost" size="sm">
                                     <CheckSquare className="mr-2 h-4 w-4" />
                                     Todos

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -2,27 +2,29 @@ import { CheckSquare, Home } from "lucide-react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import LogoutButton from "../modules/auth/components/logout-button";
+import dashboardRoutes from "@/modules/dashboard/dashboard.route";
+import todosRoutes from "@/modules/todos/todos.route";
 
 export function Navigation() {
     return (
-        <nav className="border-b bg-white sticky top-0 z-50">
+        <nav className="border-b bg-card sticky top-0 z-50">
             <div className="container mx-auto px-4 py-3">
                 <div className="flex items-center justify-between">
                     <div className="flex items-center space-x-6">
                         <Link
-                            href="/"
-                            className="text-xl font-bold text-gray-900"
+                            href={dashboardRoutes.dashboard}
+                            className="text-xl font-bold"
                         >
                             TodoApp
                         </Link>
                         <div className="items-center space-x-4 hidden md:flex">
-                            <Link href="/">
+                            <Link href={dashboardRoutes.dashboard}>
                                 <Button variant="ghost" size="sm">
                                     <Home className="mr-2 h-4 w-4" />
                                     Home
                                 </Button>
                             </Link>
-                            <Link href="/dashboard/todos">
+                            <Link href={todosRoutes.list}>
                                 <Button variant="ghost" size="sm">
                                     <CheckSquare className="mr-2 h-4 w-4" />
                                     Todos


### PR DESCRIPTION
## Problem
The navigation bar has a "Todos" link that points to `/todos`, but the actual route is `/dashboard/todos`. This causes a 404 error when users click the link.

## Solution
Update the link in `src/components/navigation.tsx` from `/todos` to `/dashboard/todos` to match the actual route structure.

## Testing
- ✅ Clicked "Todos" link in navigation - now correctly navigates to todos page
- ✅ No 404 error

## Changes
- Modified `src/components/navigation.tsx:25`
- Changed `href="/todos"` to `href="/dashboard/todos"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Navigation Updates**
  * Logo and Home now route to the dashboard; Todos link routes to the Todos list to streamline navigation.
* **Style**
  * Navigation bar background updated to a card-style theme and adjusted link text sizing for improved visual consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->