### PR TITLE
fix: correct typos in SummarizerService

### DIFF
--- a/src/services/summarizer.service.ts
+++ b/src/services/summarizer.service.ts
@@ -44,7 +44,7 @@ export class SummarizerService {
             language = "English",
         } = config || {};
 
-        const systemPrompt = this.buildSystenPrompt(maxLength, style, language);
+        const systemPrompt = this.buildSystemPrompt(maxLength, style, language);
 
         // Estimate tokens (rough calculation: 1 token ≈ 4 characters)
         const inputTokens = Math.ceil((systemPrompt.length + text.length) / 4);
@@ -73,12 +73,12 @@ export class SummarizerService {
         };
     }
 
-    private buildSystenPrompt(
+    private buildSystemPrompt(
         maxLength: number,
         style: string,
         language: string,
     ): string {
-        const styleInstructructions: Record<SummaryStyles, string> = {
+        const styleInstructions: Record<SummaryStyles, string> = {
             concise:
                 "Create a brief, concise summary focusing on the main points.",
             detailed:
@@ -87,7 +87,7 @@ export class SummarizerService {
                 "Create a summary using bullet points to highlight key information.",
         };
 
-        return `You are a professional text summarizer. ${styleInstructructions[style as keyof typeof styleInstructructions]}
+        return `You are a professional text summarizer. ${styleInstructions[style as keyof typeof styleInstructions]}
         
                 Instructions:
                     - Summarize in ${language}


### PR DESCRIPTION
## Problem
Multiple typos in `src/services/summarizer.service.ts`:
- `buildSystenPrompt` should be `buildSystemPrompt`
- `styleInstructructions` misspelled as `styleInstructructions`

## Solution
Fix all typos to use correct spelling.

## Changes
- Line 47: Method call typo
- Line 76: Method name typo  
- Lines 81, 90: Variable name typo

## Impact
- Improves code readability
- No functional changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Corrected internal naming inconsistencies to improve code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->