### PR TITLE
fix: replace alert() with toast notification in DeleteTodo

### DIFF
--- a/src/modules/todos/components/delete-todo.tsx
+++ b/src/modules/todos/components/delete-todo.tsx
@@ -2,6 +2,7 @@
 
 import { Trash2 } from "lucide-react";
 import { useState, useTransition } from "react";
+import toast from "react-hot-toast";
 import {
     AlertDialog,
     AlertDialogAction,
@@ -37,7 +38,7 @@ export function DeleteTodo({ todoId }: DeleteTodoProps) {
                 setIsOpen(false);
             } catch (error) {
                 console.error("Error deleting todo:", error);
-                alert(
+                toast.error(
                     `Error deleting todo: ${error instanceof Error ? error.message : "Unknown error"}`,
                 );
             }


### PR DESCRIPTION
## Problem
The `DeleteTodo` component uses browser `alert()` for error messages (line 40-42), which:
- Blocks the entire page
- Looks unprofessional  
- Doesn't match the app's design
- The project already has `react-hot-toast` installed but isn't using it here

## Solution
Replace `alert()` with `toast.error()` from the already-imported toast library.

## Benefits
- ✅ Non-blocking notifications
- ✅ Styled to match app design
- ✅ Consistent with error handling elsewhere
- ✅ Better user experience

## Testing
- Tested delete error scenario
- Toast notification displays correctly
- No page blocking

## Changes
- Line 4: Import `toast` from react-hot-toast
- Line 40: Replace `alert()` with `toast.error()`