### PR TITLE
fix: add aria-label to delete button for accessibility

### DIFF
--- a/src/modules/todos/components/delete-todo.tsx
+++ b/src/modules/todos/components/delete-todo.tsx
@@ -51,6 +51,7 @@ export function DeleteTodo({ todoId }: DeleteTodoProps) {
                     variant="ghost"
                     size="sm"
                     className="text-red-600 hover:text-red-700 hover:bg-red-50"
+                    aria-label="Delete todo"
                 >
                     <Trash2 className="h-4 w-4" />
                 </Button>


### PR DESCRIPTION
## Problem
The delete button in `DeleteTodo` component only has an icon with no text, making it inaccessible to screen reader users. This violates WCAG 2.1 accessibility guidelines.

## Solution  
Add `aria-label="Delete todo"` to the button element to provide accessible text for assistive technologies.

## Benefits
- ✅ Screen readers can announce button purpose
- ✅ Complies with WCAG 2.1 Level A standards
- ✅ Better accessibility for users with disabilities  
- ✅ No visual changes to UI

## Testing
- Screen reader testing (button now announces "Delete todo")
- Visual appearance unchanged

## Changes
- Line 53: Add `aria-label` attribute to Button component