### PR TITLE
fix: add file size and type validation for image uploads

### DIFF
--- a/src/modules/todos/components/todo-form.tsx
+++ b/src/modules/todos/components/todo-form.tsx
@@ -5,6 +5,7 @@ import { Upload, X } from "lucide-react";
 import Image from "next/image";
 import { useState, useTransition } from "react";
 import { useForm } from "react-hook-form";
+import toast from "react-hot-toast";
 import type { z } from "zod";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -108,6 +109,22 @@ export function TodoForm({
     const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         const file = e.target.files?.[0];
         if (file) {
+            // Validate file size (5MB = 5 * 1024 * 1024 bytes)
+            const maxSize = 5 * 1024 * 1024;
+            if (file.size > maxSize) {
+                toast.error("Image must be less than 5MB");
+                e.target.value = ""; // Reset input
+                return;
+            }
+
+            // Validate file type
+            const validTypes = ["image/png", "image/jpeg", "image/jpg"];
+            if (!validTypes.includes(file.type)) {
+                toast.error("Only PNG and JPG images are allowed");
+                e.target.value = ""; // Reset input
+                return;
+            }
+
             setImageFile(file);
             const reader = new FileReader();
             reader.onloadend = () => {


### PR DESCRIPTION
## Problem
The todo form says "PNG, JPG up to 5MB" but doesn't actually validate:
- File size (users can upload gigabyte files)
- File type (users can upload any file type)

This can cause:
- Upload failures
- Server errors
- Wasted bandwidth
- Poor user experience

## Solution
Add client-side validation in `handleImageChange`:
- Check file size ≤ 5MB
- Check file type is PNG or JPG
- Show toast error for invalid files
- Reset file input on error

## Benefits
- ✅ Prevents large file uploads before they start
- ✅ Clear error messages to users
- ✅ Matches documented requirements
- ✅ Better user experience

## Testing
- ✅ Tested with 6MB file - shows error
- ✅ Tested with PDF file - shows error
- ✅ Tested with valid 2MB PNG - works correctly

## Changes
- Line 7: Import toast
- Lines 111-125: Add file validation logic