### PR TITLE
fix: prevent double https:// in R2 public URLs

### DIFF
--- a/src/lib/r2.ts
+++ b/src/lib/r2.ts
@@ -46,7 +46,8 @@ export async function uploadToR2(
         }
 
         // Return public URL of R2 (should be using custom domain)
-        const publicUrl = `https://${(env as any).CLOUDFLARE_R2_URL}/${key}`;
+        // CLOUDFLARE_R2_URL already includes the protocol (https://)
+        const publicUrl = `${(env as any).CLOUDFLARE_R2_URL}/${key}`;
 
         return {
             success: true,


### PR DESCRIPTION
## Problem
The `CLOUDFLARE_R2_URL` environment variable already includes the protocol prefix (`https://`), as shown in the README examples:
```
CLOUDFLARE_R2_URL=https://pub-a1b2c3d4e5f6g7h8i9j0.r2.dev
```

However, the code in `src/lib/r2.ts:49` was prepending another `https://`, resulting in malformed URLs like:
```
https://https://pub-a1b2c3d4e5f6g7h8i9j0.r2.dev/uploads/...
```

## Solution
Remove the hardcoded `https://` prefix and use the environment variable value directly.

## Changes
- `src/lib/r2.ts`: Updated public URL construction to not prepend protocol
- Added comment explaining that `CLOUDFLARE_R2_URL` already includes protocol

## Impact
This fixes image uploads that would have failed due to invalid URLs being stored in the database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)