### PR TITLE
fix: add NEXT_REDIRECT error handling to update todo action

### DIFF
--- a/src/modules/todos/actions/update-todo.action.ts
+++ b/src/modules/todos/actions/update-todo.action.ts
@@ -86,6 +86,11 @@ export async function updateTodoAction(todoId: number, formData: FormData) {
         revalidatePath(todosRoutes.list);
         redirect(todosRoutes.list);
     } catch (error) {
+        // Handle Next.js redirect errors - these are not actual errors
+        if (error instanceof Error && error.message === "NEXT_REDIRECT") {
+            throw error; // Re-throw redirect errors as-is
+        }
+
         console.error("Error updating todo:", error);
 
         if (


### PR DESCRIPTION
## Problem
The `updateTodoAction` was missing proper handling for Next.js redirect errors. When `redirect()` is called from a server action, it throws a special error with message `"NEXT_REDIRECT"` that should be re-thrown unchanged to allow the redirect to complete properly.

Without this handling, redirect errors would:
- Be logged as errors in the console (false alarm)
- Potentially be wrapped in generic error messages
- Cause confusion during debugging

## Solution
Add NEXT_REDIRECT error handling to match the pattern already used in `createTodoAction`.

## Changes
- `src/modules/todos/actions/update-todo.action.ts`: 
  - Check if error message is `'NEXT_REDIRECT'` before error logging
  - Re-throw NEXT_REDIRECT errors unchanged
  - Prevents false error logs for successful operations

## Pattern Consistency
This fix brings `updateTodoAction` in line with `createTodoAction` which already has this handling:

```typescript
// Handle Next.js redirect errors - these are not actual errors
if (error instanceof Error && error.message === "NEXT_REDIRECT") {
    throw error; // Re-throw redirect errors as-is
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)