### PR TITLE
fix: replace alert() with toast in toggle-complete component

### DIFF
--- a/src/modules/todos/components/toggle-complete.tsx
+++ b/src/modules/todos/components/toggle-complete.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useTransition } from "react";
+import toast from "react-hot-toast";
 import { Checkbox } from "@/components/ui/checkbox";
 import { updateTodoFieldAction } from "../actions/update-todo.action";
 
@@ -31,8 +32,8 @@ export function ToggleComplete({ todoId, completed }: ToggleCompleteProps) {
                 console.error("Error updating todo:", error);
                 // Revert the optimistic update
                 setIsCompleted(!checked);
-                alert(
-                    `Error updating todo: ${error instanceof Error ? error.message : "Unknown error"}`,
+                toast.error(
+                    error instanceof Error ? error.message : "Failed to update todo",
                 );
             }
         });


### PR DESCRIPTION
## Summary
Replaces blocking `alert()` call with non-blocking toast notification for consistent error feedback across the application.

## Changes
- Import `react-hot-toast` in toggle-complete component
- Replace `alert()` with `toast.error()` for error notifications
- Simplify error message to match other components

## Benefits
- **Consistent UX**: Matches error handling in delete-todo.tsx (PR #14)
- **Non-blocking**: Toast notifications don't interrupt user workflow
- **Professional**: Modern error feedback pattern

## Testing
- Toggle todo completion
- Verify error shows as toast notification (not alert) if update fails

Related to PR #14 (replaced alert in delete-todo.tsx)