### PR TITLE
feat: add success feedback for todo create/edit operations

### DIFF
--- a/src/modules/todos/components/todo-form.tsx
+++ b/src/modules/todos/components/todo-form.tsx
@@ -3,8 +3,10 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Upload, X } from "lucide-react";
 import Image from "next/image";
+import { useRouter } from "next/navigation";
 import { useState, useTransition } from "react";
 import { useForm } from "react-hook-form";
+import toast from "react-hot-toast";
 import type { z } from "zod";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -72,6 +74,7 @@ export function TodoForm({
     categories: initialCategories,
     initialData,
 }: TodoFormProps) {
+    const router = useRouter();
     const [isPending, startTransition] = useTransition();
     const [imageFile, setImageFile] = useState<File | null>(null);
     const [imagePreview, setImagePreview] = useState<string | null>(
@@ -162,12 +165,21 @@ export function TodoForm({
                     formData.append("image", imageFile);
                 }
 
-                if (initialData) {
-                    await updateTodoAction(initialData.id, formData);
-                } else {
-                    await createTodoAction(formData);
-                }
+                // Show success feedback before redirect
+                const actionPromise = initialData
+                    ? updateTodoAction(initialData.id, formData)
+                    : createTodoAction(formData);
+
+                await toast.promise(actionPromise, {
+                    loading: initialData ? "Updating todo..." : "Creating todo...",
+                    success: initialData
+                        ? "Todo updated successfully!"
+                        : "Todo created successfully!",
+                    error: (err) =>
+                        err instanceof Error ? err.message : "Failed to save todo",
+                });
             } catch (error) {
+                // Error already shown by toast.promise
                 console.error("Error saving todo:", error);
             }
         });


### PR DESCRIPTION
## Summary
Adds clear user feedback during todo creation and editing using toast notifications.

## Changes
- Import `react-hot-toast` and `useRouter` in todo-form component
- Use `toast.promise()` to show loading, success, and error states
- Display "Creating/Updating todo..." during operation
- Show success message before redirect completes

## Benefits
- **Clear feedback**: Users see confirmation that their action succeeded
- **Loading state**: Shows "Creating/Updating todo..." during operation
- **Error handling**: Displays specific error messages if operation fails
- **Professional UX**: Modern promise-based toast pattern

## User Experience
**Before**: Form submits → redirect happens → no feedback
**After**: Form submits → "Creating todo..." → "Todo created successfully!" → redirect

## Testing
1. Create a new todo → see "Creating todo..." then "Todo created successfully!"
2. Edit existing todo → see "Updating todo..." then "Todo updated successfully!"
3. Verify redirect still works after success message

Addresses missing success feedback identified in UX improvement audit.