### PR TITLE
feat: add loading indicator for image uploads in todo form

### DIFF
--- a/src/modules/todos/components/todo-form.tsx
+++ b/src/modules/todos/components/todo-form.tsx
@@ -499,17 +499,46 @@ export function TodoForm({
                                 type="button"
                                 variant="outline"
                                 onClick={() => window.history.back()}
+                                disabled={isPending}
                             >
                                 Cancel
                             </Button>
                             <Button type="submit" disabled={isPending}>
-                                {isPending
-                                    ? initialData
-                                        ? "Updating..."
-                                        : "Creating..."
-                                    : initialData
-                                      ? "Update Todo"
-                                      : "Create Todo"}
+                                {isPending ? (
+                                    <span className="flex items-center gap-2">
+                                        <svg
+                                            className="animate-spin h-4 w-4"
+                                            xmlns="http://www.w3.org/2000/svg"
+                                            fill="none"
+                                            viewBox="0 0 24 24"
+                                        >
+                                            <circle
+                                                className="opacity-25"
+                                                cx="12"
+                                                cy="12"
+                                                r="10"
+                                                stroke="currentColor"
+                                                strokeWidth="4"
+                                            />
+                                            <path
+                                                className="opacity-75"
+                                                fill="currentColor"
+                                                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                                            />
+                                        </svg>
+                                        {imageFile
+                                            ? initialData
+                                                ? "Updating with image..."
+                                                : "Creating with image..."
+                                            : initialData
+                                              ? "Updating..."
+                                              : "Creating..."}
+                                    </span>
+                                ) : initialData ? (
+                                    "Update Todo"
+                                ) : (
+                                    "Create Todo"
+                                )}
                             </Button>
                         </div>
                     </form>


### PR DESCRIPTION
## Summary
Adds visual loading feedback during todo form submission, with specific messaging when images are being uploaded.

## Changes
- Add animated spinner icon to submit button during submission
- Context-aware loading text:
  - "Creating with image..." → New todo + image upload
  - "Updating with image..." → Edit todo + image upload
  - "Creating..." / "Updating..." → No image
- Disable cancel button during submission
- Uses Tailwind `animate-spin` utility

## User Experience

**Before**: Click submit → button shows "Creating..." → no indication of image upload

**After**: Click submit with image → spinner appears → "Creating with image..." → clear feedback

## Benefits
- **Progress indicator**: Spinning icon shows active operation
- **Context awareness**: Different messages for image vs. no-image submissions
- **User confidence**: Clear feedback during potentially slow R2 uploads
- **Prevents double-submit**: Disabled state + visual feedback

## Code Quality
- No external dependencies (uses inline SVG spinner)
- Conditional rendering based on `isPending` and `imageFile` states
- Consistent with existing form patterns

## Testing
1. Create todo without image → See "Creating..." with spinner
2. Create todo with image → See "Creating with image..." with spinner  
3. Edit todo with image → See "Updating with image..." with spinner
4. Verify cancel button disabled during submission

Part of UX improvements to provide better feedback during async operations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unintended user actions by disabling the Cancel button while save operations are actively in progress.

* **New Features**
  * Enhanced user experience during form submission with dynamic visual feedback including status indicators and contextual messaging that clearly indicates the operation type (create or update) and specifies whether images are being included or processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->